### PR TITLE
Fix library for ESP32 MCU

### DIFF
--- a/BlueDot_BME280.cpp
+++ b/BlueDot_BME280.cpp
@@ -13,13 +13,13 @@
 
 BlueDot_BME280::BlueDot_BME280()
 {
-	parameter.communication;
-	parameter.I2CAddress;
-	parameter.sensorMode;
-	parameter.IIRfilter;
-	parameter.tempOversampling;
-	parameter.pressOversampling;
-	parameter.humidOversampling;
+	parameter.communication = 0;
+	parameter.I2CAddress = 0;
+	parameter.sensorMode = 0;
+	parameter.IIRfilter = 0;
+	parameter.tempOversampling = 0;
+	parameter.pressOversampling = 0;
+	parameter.humidOversampling = 0;
 	parameter.pressureSeaLevel = 0;
 	parameter.tempOutsideCelsius = 999;
 	parameter.tempOutsideFahrenheit = 999;
@@ -61,7 +61,7 @@ uint8_t BlueDot_BME280::init(void)
 	}
 	else														//Default I2C Communication 
 	{
-		Wire.begin();											//Default value for Arduino Boards
+                Wire.begin();											//Default value for Arduino Boards
 		//Wire.begin(0,2);										//Use this for NodeMCU board; SDA = GPIO0 = D3; SCL = GPIO2 = D4
 	}
 
@@ -220,21 +220,21 @@ float BlueDot_BME280::convertTempKelvin(void)
 		
 	float tempOutsideKelvin;	
 	
-	if (parameter.tempOutsideCelsius != 999 & parameter.tempOutsideFahrenheit == 999 )   
+	if (parameter.tempOutsideCelsius != 999 && parameter.tempOutsideFahrenheit == 999 )   
 	{
 		tempOutsideKelvin = parameter.tempOutsideCelsius;
 		tempOutsideKelvin = tempOutsideKelvin + 273.15;
 		return tempOutsideKelvin;		
 	}
 	
-	if (parameter.tempOutsideCelsius != 999 & parameter.tempOutsideFahrenheit != 999 )   
+	if (parameter.tempOutsideCelsius != 999 && parameter.tempOutsideFahrenheit != 999 )   
 	{
 		tempOutsideKelvin = parameter.tempOutsideCelsius;
 		tempOutsideKelvin = tempOutsideKelvin + 273.15;
 		return tempOutsideKelvin;		
 	}
 	
-	if (parameter.tempOutsideFahrenheit != 999 & parameter.tempOutsideCelsius == 999)
+	if (parameter.tempOutsideFahrenheit != 999 && parameter.tempOutsideCelsius == 999)
 	{
 		
 		tempOutsideKelvin = (parameter.tempOutsideFahrenheit - 32);
@@ -244,7 +244,7 @@ float BlueDot_BME280::convertTempKelvin(void)
 		return tempOutsideKelvin;	
 	}
 	
-	if (parameter.tempOutsideFahrenheit == 999 & parameter.tempOutsideCelsius == 999)
+	if (parameter.tempOutsideFahrenheit == 999 && parameter.tempOutsideCelsius == 999)
 	{
 		tempOutsideKelvin = 273.15 + 15;
 		return tempOutsideKelvin; 
@@ -427,7 +427,7 @@ uint8_t BlueDot_BME280::readByte(byte reg)
 		Wire.beginTransmission(parameter.I2CAddress);
 		Wire.write(reg);
 		Wire.endTransmission();
-		Wire.requestFrom(parameter.I2CAddress,1);		
+		Wire.requestFrom(parameter.I2CAddress, (uint8_t)1);		
 		value = Wire.read();		
 		return value;
 	}


### PR DESCRIPTION
Compiler for ESP32 is very strict and return many errors.
This patch fix these errors and allows to use library with ESP32 MCU.